### PR TITLE
Basic PHP syntax checking

### DIFF
--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -1,0 +1,31 @@
+name: Lint PHP
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ['8.1', '8.2']
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php-version }}
+
+    - name: Check Composer lock file is up to date
+      run: composer validate --no-check-all
+
+    - name: Check PHP syntax
+      run: composer syntax
+
+    - name: Install Composer dependencies
+      run: composer install --no-progress --prefer-dist --optimize-autoloader
+
+    - name: Run linter
+      run: composer lint

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules
 npm-debug.log
+/vendor/

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,29 @@
+{
+    "name": "mitlibraries/mitlibraries-theme-omeka",
+    "description": "Description here",
+    "type": "omeka-theme",
+    "authors": [
+        {
+            "name": "MIT Libraries"
+        }
+    ],
+    "require-dev": {
+        "dealerdirect/phpcodesniffer-composer-installer": "^1.0"
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "composer/installers": true
+        },
+        "sort-packages": true
+    },
+    "scripts": {
+        "syntax": [
+            "find . -path ./vendor -prune -o \\( -name '*.php' \\) -exec php -d error_reporting=E_ALL -lf {} \\;",
+            "find . -path ./vendor -prune -o \\( -name '*.phtml' \\) -exec php -d error_reporting=E_ALL -lf {} \\;"
+        ],
+        "lint": [
+            "phpcs"
+        ]
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,154 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "3511d3ca226c662fe9dfc219018b4b78",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/composer-installer.git",
+                "reference": "4be43904336affa5c2f70744a348312336afd0da"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/4be43904336affa5c2f70744a348312336afd0da",
+                "reference": "4be43904336affa5c2f70744a348312336afd0da",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.3.1",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/composer-installer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcbf",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+                "source": "https://github.com/PHPCSStandards/composer-installer"
+            },
+            "time": "2023-01-05T11:28:13+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+            },
+            "time": "2023-02-22T23:07:41+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.3.0"
+}

--- a/config/theme.ini
+++ b/config/theme.ini
@@ -1,6 +1,6 @@
 [info]
 name = "Tesseract"
-version = "0.0.2"
+version = "0.0.3"
 author = "MIT Libraries"
 description = "An Omeka S theme to implement the MIT Libraries' branding materials"
 theme_link = "https://github.com/MITLibraries/mitlibraries-theme-omeka"

--- a/config/theme.ini
+++ b/config/theme.ini
@@ -6,3 +6,11 @@ description = "An Omeka S theme to implement the MIT Libraries' branding materia
 theme_link = "https://github.com/MITLibraries/mitlibraries-theme-omeka"
 author_link = "https://libraries.mit.edu"
 omeka_version_constraint = "^4.0.0"
+
+helpers[] = "FooterHelper"
+
+[config]
+elements.analytics_property.name = "analytics_property"
+elements.analytics_property.type = "Text"
+elements.analytics_property.options.label = "Analytics Property ID"
+elements.analytics_property.options.info = "This is the Matomo property ID, and can be provided by UXWS"

--- a/helper/FooterHelper.php
+++ b/helper/FooterHelper.php
@@ -1,13 +1,20 @@
-<?php 
+<?php
+
+/**
+ * A demonstration helper class that mostly exists to give our PHP analysis
+ * tools something to work with.
+ *
+ * @url https://omeka.org/s/docs/developer/themes/theme_functions/
+ */
+
 namespace OmekaTheme\Helper;
 
 use Laminas\View\Helper\AbstractHelper;
 
-class FooHelper extends AbstractHelper
+class FooterHelper extends AbstractHelper
 {
-    public function __invoke($msg = '') 
+    public function __invoke($msg = '')
     {
-        // your code here
-        echo "Helper: ${msg}";
+        echo "<span>Helper: {$msg}</span>";
     }
 }

--- a/helper/FooterHelper.php
+++ b/helper/FooterHelper.php
@@ -1,0 +1,13 @@
+<?php 
+namespace OmekaTheme\Helper;
+
+use Laminas\View\Helper\AbstractHelper;
+
+class FooHelper extends AbstractHelper
+{
+    public function __invoke($msg = '') 
+    {
+        // your code here
+        echo "Helper: ${msg}";
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mitlibraries-theme-omeka",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mitlibraries-theme-omeka",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "devDependencies": {
         "autoprefixer": "^10.4.15",
         "gulp": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mitlibraries-theme-omeka",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "An Omeka S theme to implement the MIT Libraries' branding materials",
   "main": "gulpfile.js",
   "scripts": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<ruleset name="Omeka">
+    <description>Omeka Coding Standards</description>
+
+    <!-- Scan all files in directory -->
+    <file>.</file>
+
+    <!-- Scan only PHP files -->
+    <arg name="extensions" value="phtml,php"/>
+
+    <exclude-pattern>node_modules/</exclude-pattern>
+    <exclude-pattern>vendor/</exclude-pattern>
+
+    <!-- Show colors in console -->
+    <arg value="-colors"/>
+
+    <!-- Show sniff codes in all reports -->
+    <arg value="ns"/>
+
+    <rule ref="PSR2"/>
+</ruleset>

--- a/view/layout/layout.phtml
+++ b/view/layout/layout.phtml
@@ -1,0 +1,33 @@
+<?php
+$translate = $this->plugin('translate');
+$this->headMeta()->setCharset('utf-8');
+$this->headMeta()->appendName('viewport', 'width=device-width, initial-scale=1');
+$this->headLink()->prependStylesheet('//fonts.googleapis.com/css?family=Source+Code+Pro|Lato:400,400italic,700,700italic');
+$this->headTitle($this->setting('installation_title', 'Omeka S'))->setSeparator(' · ');
+$this->headLink()->appendStylesheet($this->assetUrl('css/iconfonts.css', 'Omeka'));
+$this->headLink()->appendStylesheet($this->assetUrl('css/style.css', 'Omeka'));
+$this->headScript()->prependFile($this->assetUrl('vendor/jquery/jquery.min.js', 'Omeka'));
+$this->headScript()->appendFile($this->assetUrl('js/global.js', 'Omeka'));
+$this->trigger('view.layout');
+$userBar = $this->userBar();
+?>
+<?php echo $this->doctype(); ?>
+<?php echo $this->htmlElement('html')->setAttribute('lang', $this->lang()); ?>
+    <head>
+        <?php echo $this->headMeta(); ?>
+        <?php echo $this->headTitle(); ?>
+        <?php echo $this->headLink(); ?>
+        <?php echo $this->headStyle(); ?>
+        <?php echo $this->headScript(); ?>
+    </head>
+    <?php echo $this->htmlElement('body')->appendAttribute('class', 'minimal'); ?>
+        <?php echo $userBar; ?>
+        <div id="content" role="main">
+            <?php echo $this->messages(); ?>
+            <?php echo $this->content; ?>
+        </div>
+        <footer>
+            <span class="powered-by"><?php echo $translate('Powered by Omeka S'); ?></span>
+        </footer>
+    </body>
+</html>

--- a/view/layout/layout.phtml
+++ b/view/layout/layout.phtml
@@ -29,8 +29,8 @@ $userBar = $this->userBar();
             <?php echo $this->content; ?>
         </div>
         <footer>
+            <?php echo $this->FooterHelper($analytics_property); ?>
             <span class="powered-by"><?php echo $translate('Powered by Omeka S'); ?></span>
         </footer>
-        <?php echo $this->FooterHelper( $analytics_property ); ?>
     </body>
 </html>

--- a/view/layout/layout.phtml
+++ b/view/layout/layout.phtml
@@ -1,5 +1,7 @@
 <?php
 $translate = $this->plugin('translate');
+$analytics_property = $this->themeSetting('analytics_property');
+
 $this->headMeta()->setCharset('utf-8');
 $this->headMeta()->appendName('viewport', 'width=device-width, initial-scale=1');
 $this->headLink()->prependStylesheet('//fonts.googleapis.com/css?family=Source+Code+Pro|Lato:400,400italic,700,700italic');
@@ -29,5 +31,6 @@ $userBar = $this->userBar();
         <footer>
             <span class="powered-by"><?php echo $translate('Powered by Omeka S'); ?></span>
         </footer>
+        <?php echo $this->FooterHelper( $analytics_property ); ?>
     </body>
 </html>


### PR DESCRIPTION
### Why these changes are being introduced

In addition to the last PR (#3) which introduced tooling for Javascript, we also need tooling for PHP dependencies and analysis.


### How this addresses that need

This adds:
* PHP linting and syntax checking, implemented via PHPCodeSniffer (PHPCS) and PHP's core tooling. This approach is modeled after the one we're using for our WordPress network.
* The PHPCS configuration file added here applies the [PSR2 standard](https://www.php-fig.org/psr/psr-2/), and extends coverage to both PHP files as well as PHTML templates.
* There is a GH Action specified which will run both the linting and syntax checking under both current versions of PHP. All checks are currently required to pass for PR's to merge (there is a process for whitelisting lines of code that require an exception, documented within PHPCS but not here).
* In order for the analysis tools to have something to do, this adds one PHTML template file (copy-paste from Omeka core, and will be customized in future work) and one PHP helper library (not sure if this will survive the project, frankly - the need for helpers is still TBD). There is a commit to show how the tools will flag various problems, and then a final commit to fix some problems to result in passing checks.

### Side effects of this change

* This bumps the theme version to 0.0.3, recorded primarily in `config/theme.ini` but repeated in `package.json`. It isn't great to repeat this value in multiple places, but I haven't worked out how to eliminate this repetition yet. 
* Omeka does not use PHPCS internally - they use a different tool, [PHP-CS-Fixer](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer). Additionally, they've put together [a configuration file](https://github.com/omeka/omeka-s/blob/develop/.php-cs-fixer.dist.php) to customize their interpretation of the PSR2 standard. I don't see a good way to follow this lead, even if we adopt their scanning tool, without manual copy-pasting - so I'm proposing that we keep using the same PHP tool across PHP projects. If we want to adapt their scanning configuration down the road, we can do that.


### Relevant ticket(s)

* https://mitlibraries.atlassian.net/browse/POST-21
