### PR TITLE
Create deployment automation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,3 +13,4 @@
 # in the format @org/team-name. Teams must have explicit write access to the
 # repository.
 /.github/workflows/ @mitlibraries/engx @mitlibraries/infraeng
+Makefile @mitlibraries/engx @mitlibraries/infraeng

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# Based off the GitHub CODEOWNERS template at https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file
+
+################################################################################
+# These owners will be the default owners for everything in the repo. Unless a
+# later match takes precedence, @global-owner1 and @global-owner2 will be
+# requested for review when someone opens a pull request.
+*       @matt-bernhardt @mitlibraries/engx
+
+# Order is important! The last matching pattern takes the most precedence.
+
+################################################################################
+# Teams can be specified as code owners as well. Teams should # be identified
+# in the format @org/team-name. Teams must have explicit write access to the
+# repository.
+/.github/workflows/ @mitlibraries/engx @mitlibraries/infraeng

--- a/.github/workflows/dev-manual.yml
+++ b/.github/workflows/dev-manual.yml
@@ -1,12 +1,11 @@
-name: deploy-to-prod
+name: manual-deploy-to-stage
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
 
 jobs:
   deploy-theme:
     name: deploy-theme
-    runs-on: [self-hosted, linux, prod]
+    runs-on: [self-hosted, linux, stage]
     steps:
       - uses: actions/checkout@v4
       - name: deploy-theme

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -1,0 +1,13 @@
+name: deploy-to-stage
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy-theme:
+    name: deploy-theme
+    runs-on: [self-hosted, linux, prod]
+    steps:
+      - uses: actions/checkout@v4
+      - name: deploy-theme
+        run: make deploy

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -1,4 +1,4 @@
-name: deploy-to-stage
+name: deploy-to-prod
 on:
   release:
     types: [published]

--- a/.github/workflows/stage-deploy.yml
+++ b/.github/workflows/stage-deploy.yml
@@ -1,0 +1,19 @@
+name: deploy-to-stage
+on:
+  push:
+    paths:
+      - 'asset/**'
+      - 'config/**'
+      - 'helper/**'
+      - 'view/**'
+    branches:
+      - main
+
+jobs:
+  deploy-theme:
+    name: deploy-theme
+    runs-on: [self-hosted, linux, stage]
+    steps:
+      - uses: actions/checkout@v4
+      - name: deploy-theme
+        run: make deploy

--- a/.github/workflows/stage-deploy.yml
+++ b/.github/workflows/stage-deploy.yml
@@ -16,4 +16,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: deploy-theme
-        run: make deploy
+        run: |
+          make deploy
+          echo "Deployed theme version $(grep 'version =' config/theme.ini | awk '{print $3}')" >> $GITHUB_STEP_SUMMARY

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,8 @@ update: fetch ## Synchronize latest (auto runs clean and fetch first)
 	cp tmp/mitlib-style-master/_assets/i/vi-shape7-tp.svg    asset/img/mitlib-style/vi-shape7-tp.svg
 
 deploy: ## Deploys the theme on a host server
-	rsync -a --delete asset/ /var/www/html/themes/mitlibraries-theme-omeka/asset/
+	rsync -a --delete asset/ /var/www/html/themes/mitlibraries-theme-omeka/asset/css/
+	rsync -a --delete asset/ /var/www/html/themes/mitlibraries-theme-omeka/asset/img/
 	rsync -a --delete config/ /var/www/html/themes/mitlibraries-theme-omeka/config/
 	rsync -a --delete helper/ /var/www/html/themes/mitlibraries-theme-omeka/helper/
 	rsync -a --delete view/ /var/www/html/themes/mitlibraries-theme-omeka/view/

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,8 @@ update: fetch ## Synchronize latest (auto runs clean and fetch first)
 	cp tmp/mitlib-style-master/_assets/i/vi-shape7-tp.svg    asset/img/mitlib-style/vi-shape7-tp.svg
 
 deploy: ## Deploys the theme on a host server
-	rsync -a --delete asset/ /var/www/html/themes/mitlibraries-theme-omeka/asset/css/
-	rsync -a --delete asset/ /var/www/html/themes/mitlibraries-theme-omeka/asset/img/
+	rsync -a --delete asset/css/ /var/www/html/themes/mitlibraries-theme-omeka/asset/css/
+	rsync -a --delete asset/img/ /var/www/html/themes/mitlibraries-theme-omeka/asset/img/
 	rsync -a --delete config/ /var/www/html/themes/mitlibraries-theme-omeka/config/
 	rsync -a --delete helper/ /var/www/html/themes/mitlibraries-theme-omeka/helper/
 	rsync -a --delete view/ /var/www/html/themes/mitlibraries-theme-omeka/view/

--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,9 @@ update: fetch ## Synchronize latest (auto runs clean and fetch first)
 	cp tmp/mitlib-style-master/_assets/i/favicon.ico         asset/img/mitlib-style/favicon.ico
 	cp tmp/mitlib-style-master/_assets/i/mitlib-wordmark.svg asset/img/mitlib-style/mitlib-wordmark.svg
 	cp tmp/mitlib-style-master/_assets/i/vi-shape7-tp.svg    asset/img/mitlib-style/vi-shape7-tp.svg
+
+deploy: ## Deploys the theme on a host server
+	rsync -a --delete asset/ /var/www/html/themes/mitlibraries-theme-omeka/asset/
+	rsync -a --delete config/ /var/www/html/themes/mitlibraries-theme-omeka/config/
+	rsync -a --delete helper/ /var/www/html/themes/mitlibraries-theme-omeka/helper/
+	rsync -a --delete view/ /var/www/html/themes/mitlibraries-theme-omeka/view/

--- a/docs/architecture-decisions/0004-github-runner-for-automated-deployment.md
+++ b/docs/architecture-decisions/0004-github-runner-for-automated-deployment.md
@@ -1,4 +1,4 @@
-# 4. Inherit style library materials with makefile
+# 4. USe Github Runner for automated deployment
 
 Date: 2023-10-13
 

--- a/docs/architecture-decisions/0004-github-runner-for-automated-deployment.md
+++ b/docs/architecture-decisions/0004-github-runner-for-automated-deployment.md
@@ -1,0 +1,30 @@
+# 4. Inherit style library materials with makefile
+
+Date: 2023-10-13
+
+## Status
+
+Proposed
+
+## Context
+
+We need a simple, automated, and secure way for theme updates to be deployed to the Omeka S staging server (for testing/verification) and to the production server. We want to reduce (or even eliminate) the need for any ssh connections to Omeka S host servers while allowing for EngX to deploy theme updates easily. InfraEng has already done this at least one other time (the [CloudConnector](https://github.com/MITLibraries/cloudconnector) service) so this is a known configuration and procedure.
+
+## Decision
+
+* We will configure each of the host servers as a GitHub Runner, linked only to this repository
+  * This will include updates to the repository configuration
+  * This will include the installation (via `ssh`) of the GitHub Runner application on the host servers
+* We will create GitHub Action workflows to run the theme deployment commands (e.g., `git clone`) on the servers.
+  * The deployment to the staging server will be triggered by a merge to the `main` branch
+  * The deployment to the production server will be triggered by a tagged release on the `main` branch
+
+## Related Documentation
+
+* [Adding Self-Hosted Runners](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/adding-self-hosted-runners)
+* [CloudConnector README](https://github.com/MITLibraries/cloudconnector/blob/main/README.md)
+
+## Consequences
+
+* One additional application to install/manage on the servers hosted by Digital Scholar (but based on our conversations with them, this shouldn't be an issue at all)
+* Anyone with rights in GitHub to tag releases on this repository can trigger a redeploy of the theme

--- a/docs/architecture-decisions/0004-github-runner-for-automated-deployment.md
+++ b/docs/architecture-decisions/0004-github-runner-for-automated-deployment.md
@@ -4,7 +4,7 @@ Date: 2023-10-13
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
@@ -14,8 +14,8 @@ We need a simple, automated, and secure way for theme updates to be deployed to 
 
 * We will configure each of the host servers as a GitHub Runner, linked only to this repository
   * This will include updates to the repository configuration
-  * This will include the installation (via `ssh`) of the GitHub Runner application on the host servers
-* We will create GitHub Action workflows to run the theme deployment commands (e.g., `git clone`) on the servers.
+  * This will include the installation of the GitHub Runner application on the host servers
+* We will create GitHub Action workflows to run the theme deployment commands on the servers.
   * The deployment to the staging server will be triggered by a merge to the `main` branch
   * The deployment to the production server will be triggered by a tagged release on the `main` branch
 

--- a/docs/reference/deployment-automation.md
+++ b/docs/reference/deployment-automation.md
@@ -1,0 +1,33 @@
+# Reference for deployment automation
+
+This repository is configured to automatically deploy theme updates to our staging and production servers via GitHub Actions (see [ADR0004](../architecture-decisions/0004-github-runner-for-automated-deployment.md)).
+
+## Requirements
+
+1. The repository itself is configured to use self-hosted runners (see [Add Self-Hosted Runners](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/adding-self-hosted-runners))
+1. The Omeka S host server has the GitHub Runner application installed
+1. There are two GitHub Actions workflows in this repository, one for deploys to the stage server and one for deploys to the production server.
+1. There is a special user, `mitdeploy` on the Digital Scholar hosted server that has very limited privileges (limited to read/write/delete on the `themes` and `modules` directories for the Omeka install).
+
+## GitHub Runner Installation
+
+Head to **Settings > Actions > Runners** for the repo and click the **New self-hosted runner** button. This will generate the necessary commands a token for the installation on the host server. Two other important notes.
+
+1. Make sure to set a **label** and a **name** for the running when running the config command with the following parameters `--labels <ENV> --name <NAME>` (where `<ENV>` is either `stage` or `prod` and <NAME> is either `mitlibraries-stage-omeka` or `mitlibraries-prod-omeka`). These values are used in the GitHub Actions to limit where tasks are run.
+1. Configure the runner package to run as a service (see [github runner as a service](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/configuring-the-self-hosted-runner-application-as-a-service) for details)
+
+## Workflow configuration
+
+When creating the GitHub Actions workflows, be sure to specify
+
+```bash
+    runs-on: [self-hosted, linux, stage]
+```
+
+for the stage runner/server and specify
+
+```bash
+    runs-on: [self-hosted, linux, prod]
+```
+
+for the production runner/server.

--- a/readme.md
+++ b/readme.md
@@ -1,20 +1,25 @@
 # MIT Libraries Omeka Theme
 
-This [Omeka S](https://omeka.org/s/) theme implements the MIT Libraries' current branding identity for
-web applications.
+This [Omeka S](https://omeka.org/s/) theme implements the MIT Libraries' current branding identity for web applications.
 
 Additional Omeka S themes can be found at https://github.com/omeka-s-themes.
 
 ## Using this theme
 
-This theme should be placed in the themes directory within your Omeka S
-instance. It should then be available for selection by any exhibit which needs
-it.
+This theme should be placed in the themes directory within your Omeka S instance. It should then be available for selection by any exhibit which needs it.
 
 ## Developing this theme
 
-The [Omeka S Developer Documentation for themes](https://omeka.org/s/docs/developer/themes/) should be consulted for help
-adding anything to this theme.
+The [Omeka S Developer Documentation for themes](https://omeka.org/s/docs/developer/themes/) should be consulted for help adding anything to this theme.
+
+## Deploying this theme
+
+This is automatically deployed to stage and prod via GitHub Actions. See [ADR#0004](./docs/architecture-decisions/0004-github-runner-for-automated-deployment.md) for the decision to do this. See [deployment-automation](./docs/reference/deployment-automation.md) for the details of how to setup this automation. The configuration follows our standard GitHub-flow deployment model:
+
+* A merge to `main` triggers a deploy of the theme to the stage server
+* A tagged release on `main` triggers a deploy of the theme to the prod server
+
+Only changes in the four key directories are tracked for automation: `asset/`, `config/`, `helper/`, and `view/`.
 
 ### Stylesheets
 

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 This [Omeka S](https://omeka.org/s/) theme implements the MIT Libraries' current branding identity for web applications.
 
-Additional Omeka S themes can be found at https://github.com/omeka-s-themes.
+Additional Omeka S themes can be found at [omeka-s-themes](https://github.com/omeka-s-themes).
 
 ## Using this theme
 
@@ -19,7 +19,7 @@ This is automatically deployed to stage and prod via GitHub Actions. See [ADR#00
 * A merge to `main` triggers a deploy of the theme to the stage server
 * A tagged release on `main` triggers a deploy of the theme to the prod server
 
-Only changes in the four key directories are tracked for automation: `asset/`, `config/`, `helper/`, and `view/`.
+Only changes in the four key directories are tracked for automation: `asset/`, `config/`, `helper/`, and `view/`. If there are updates to the theme that require files outside of the four directories listed above, the `deploy` command in the Makefile will need to be udpated.
 
 ### Stylesheets
 


### PR DESCRIPTION
### Why these changes are being introduced

This is the theme deployment automation for Omeka S.

### How this addresses that need

* Create stage and prod workflows for GitHub Actions to automatically deploy the theme to the Omeka S servers
* Create documentation (README and reference doc, ADR#0004)

### Side effects of this change

Once merged to main, the Actions will be enabled for commits and release on `main`.

### Other Relevant Information

At this point, the self-hosted runner for stage is configured for this repository. But, the self-hosted runner for prod has not yet been enabled. So, the prod GitHub Workflow will fail until we create that runner and configure it on the prod Omeka server.

### Relevant ticket(s)

* https://mitlibraries.atlassian.net/browse/POST-60
