### PR TITLE
Fix Deployment Automation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 # These owners will be the default owners for everything in the repo. Unless a
 # later match takes precedence, @global-owner1 and @global-owner2 will be
 # requested for review when someone opens a pull request.
-*       @matt-bernhardt @mitlibraries/engx
+# *       @matt-bernhardt @mitlibraries/engx
 
 # Order is important! The last matching pattern takes the most precedence.
 
@@ -12,5 +12,5 @@
 # Teams can be specified as code owners as well. Teams should # be identified
 # in the format @org/team-name. Teams must have explicit write access to the
 # repository.
-/.github/workflows/ @mitlibraries/engx @mitlibraries/infraeng
-Makefile @mitlibraries/engx @mitlibraries/infraeng
+# /.github/workflows/ @mitlibraries/engx @mitlibraries/infraeng
+# Makefile @mitlibraries/engx @mitlibraries/infraeng

--- a/.github/workflows/dev-manual.yml
+++ b/.github/workflows/dev-manual.yml
@@ -7,8 +7,10 @@ jobs:
     name: deploy-theme
     runs-on: [self-hosted, linux, stage]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - name: deploy-theme
         run: |
+          chown -R :client .
+          chmod -R g+w .
           make deploy
           echo "Deployed theme version $(grep 'version =' config/theme.ini | awk '{print $3}')" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -8,7 +8,16 @@ jobs:
     name: deploy-theme
     runs-on: [self-hosted, linux, prod]
     steps:
-      - uses: actions/checkout@v4
+      - name: checkout code
+        uses: actions/checkout@v4
+
+      - name: Exit if not main
+        run: |
+          if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
+            echo "Branch is not main, exiting."
+            exit 0
+          fi
+
       - name: deploy-theme
         run: |
           make deploy

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ update: fetch ## Synchronize latest (auto runs clean and fetch first)
 	cp tmp/mitlib-style-master/_assets/i/vi-shape7-tp.svg    asset/img/mitlib-style/vi-shape7-tp.svg
 
 deploy: ## Deploys the theme on a host server
+	rsync asset /var/www/html/themes/mitlibraries-theme-omeka/asset/
 	rsync --recursive --delete asset/css/ /var/www/html/themes/mitlibraries-theme-omeka/asset/css/
 	rsync --recursive --delete asset/img/ /var/www/html/themes/mitlibraries-theme-omeka/asset/img/
 	rsync --recursive --delete config/ /var/www/html/themes/mitlibraries-theme-omeka/config/

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,8 @@ update: fetch ## Synchronize latest (auto runs clean and fetch first)
 	cp tmp/mitlib-style-master/_assets/i/vi-shape7-tp.svg    asset/img/mitlib-style/vi-shape7-tp.svg
 
 deploy: ## Deploys the theme on a host server
-	rsync -a --delete asset/css/ /var/www/html/themes/mitlibraries-theme-omeka/asset/css/
-	rsync -a --delete asset/img/ /var/www/html/themes/mitlibraries-theme-omeka/asset/img/
-	rsync -a --delete config/ /var/www/html/themes/mitlibraries-theme-omeka/config/
-	rsync -a --delete helper/ /var/www/html/themes/mitlibraries-theme-omeka/helper/
-	rsync -a --delete view/ /var/www/html/themes/mitlibraries-theme-omeka/view/
+	rsync --recursive --delete asset/css/ /var/www/html/themes/mitlibraries-theme-omeka/asset/css/
+	rsync --recursive --delete asset/img/ /var/www/html/themes/mitlibraries-theme-omeka/asset/img/
+	rsync --recursive --delete config/ /var/www/html/themes/mitlibraries-theme-omeka/config/
+	rsync --recursive --delete helper/ /var/www/html/themes/mitlibraries-theme-omeka/helper/
+	rsync --recursive --delete view/ /var/www/html/themes/mitlibraries-theme-omeka/view/


### PR DESCRIPTION
### Why these changes are being introduced

The first pass at automating deployment of the theme had some issues:
* all tags were triggering deployents to prod instead of just tags on `main`
* the `make deploy` command used in workflows was failing when it tried to update file attributes (because it was using the `--archive` flag)
* the CODEOWNERS file was generating (and still is generating) too many review requests automatically

### How this addresses that need

* Correct the prod deployment workflow to stop running if the branch with the tag is not `main`
* Correct the Makefile `deploy` command to just use `--recursive` instead of `--archive`
* Correct the Makefile `deploy` command to correctly create the `asset/` folder if it is writing into an empty folder
* Comment out all the owners in the CODEOWNERS file to stop future noisy PRs

### Side effects of this change

No

