### PR TITLE
Correct Version of Checkout Action

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: [self-hosted, linux, prod]
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       - name: Exit if not main
         run: |
@@ -20,5 +20,7 @@ jobs:
 
       - name: deploy-theme
         run: |
+          chown -R :client .
+          chmod -R g+w .
           make deploy
           echo "Deployed theme version $(grep 'version =' config/theme.ini | awk '{print $3}')" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/stage-deploy.yml
+++ b/.github/workflows/stage-deploy.yml
@@ -6,6 +6,7 @@ on:
       - 'config/**'
       - 'helper/**'
       - 'view/**'
+      - 'theme.jpg'
     branches:
       - main
 
@@ -14,8 +15,10 @@ jobs:
     name: deploy-theme
     runs-on: [self-hosted, linux, stage]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - name: deploy-theme
         run: |
+          chown -R :client .
+          chmod -R g+w .
           make deploy
           echo "Deployed theme version $(grep 'version =' config/theme.ini | awk '{print $3}')" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
### Why these changes are being introduced

The correct version (v3) of the actions/checkout needed to be put in the stage and prod automated deploys (this was fixed in the manual deploy workflow previously).

### How this addresses that need

* Update the version of actions/checkout to v3 (from v4)
* Update the run command for the stage and prod deploys to match the manual deploy command

### Side effects of this change

None.