### PR TITLE
Protect .github folder and Makefile via CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,5 +12,5 @@
 # Teams can be specified as code owners as well. Teams should # be identified
 # in the format @org/team-name. Teams must have explicit write access to the
 # repository.
-# /.github/workflows/ @mitlibraries/engx @mitlibraries/infraeng
-# Makefile @mitlibraries/engx @mitlibraries/infraeng
+/.github/ @mitlibraries/engx @mitlibraries/infraeng
+Makefile @mitlibraries/engx @mitlibraries/infraeng


### PR DESCRIPTION
### Why are these changes being introduced:

* We need to have some protections in place to closely monitor changes to our workflows.

### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/post-73

### How does this address that need:

* This adds protections in our CODEOWNERS file, automatically notifying people on the EngX and InfraEng teams to proposed changes in the .github folder, and to the Makefile. Having this configuration in place should prevent code merging without someone on those two teams being informed.

### Document any side effects to this change:

* Hopefully none.
