### PR TITLE
Remove default rendering if sub-navigation

### DIFF
--- a/view/omeka/site/page/show.phtml
+++ b/view/omeka/site/page/show.phtml
@@ -16,12 +16,6 @@ if ($activePage) :
     <?php endif; ?>
 <?php endif; ?>
 
-<?php if ($activePage) : ?>
-    <?php if ($this->displayNavigation && $activePage['page']->hasPages()) : ?>
-    <nav class="sub-menu"><?php echo $nav->menu()->renderSubMenu(); ?></nav>
-    <?php endif; ?>
-<?php endif; ?>
-
 <?php $this->trigger('view.show.before'); ?>
 <div class="blocks">
     <?php echo $this->content; ?>


### PR DESCRIPTION
### Why are these changes being introduced:

* The standard page content template includes a conditional that will render a sub-navigation menu between the page title and the breadcrumb if no Table of Contents block is present in page. During testing so far, this feature has proved confusing; we've decided that it would be cleaner to remove this (at least for now) and recommend that site builders place a Table of Contents themselves if they want a duplicate navigation pathway (beyond what the main navigation will provide)

### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/post-109

### How does this address that need:

* This removes the conditional within the page content template.

Before this change

![Screenshot 2023-11-22 at 11 11 38 AM](https://github.com/MITLibraries/mitlibraries-theme-omeka/assets/1403248/ac310267-55c2-4ce6-9a8a-03fe471e3971)

After this change

![Screenshot 2023-11-22 at 11 10 58 AM](https://github.com/MITLibraries/mitlibraries-theme-omeka/assets/1403248/837b4ac6-ea81-40a2-8427-1dd6b948f7aa)

### Document any side effects to this change:

* None
