### PR TITLE
Add static Matomo integration to theme

### DIFF
--- a/asset/js/matomo.js
+++ b/asset/js/matomo.js
@@ -1,0 +1,11 @@
+var _paq = window._paq = window._paq || [];
+/* tracker methods like 'setCustomDimension' should be called before 'trackPageView' */
+_paq.push(['trackPageView']);
+_paq.push(['enableLinkTracking']);
+(function() {
+  var u='https://matomo.libraries.mit.edu/';
+  _paq.push(['setTrackerUrl', u+'matomo.php']);
+  _paq.push(['setSiteId', '9']);
+  var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+  g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+})();

--- a/config/theme.ini
+++ b/config/theme.ini
@@ -10,11 +10,6 @@ omeka_version_constraint = "^4.0.0"
 helpers[] = "FooterHelper"
 
 [config]
-elements.analytics_property.name = "analytics_property"
-elements.analytics_property.type = "Text"
-elements.analytics_property.options.label = "Analytics Property ID"
-elements.analytics_property.options.info = "This is the Matomo property ID, and can be provided by UXWS"
-
 elements.banner.name = "banner"
 elements.banner.type = "Omeka\Form\Element\Asset"
 elements.banner.options.label = "Site banner"

--- a/view/layout/layout.phtml
+++ b/view/layout/layout.phtml
@@ -26,6 +26,7 @@ $this->headScript()->prependFile($this->assetUrl('vendor/jquery/jquery.min.js', 
 $this->headScript()->appendFile($this->assetUrl('js/global.js', 'Omeka'));
 $this->headScript()->appendFile($this->assetUrl('js/smartmenus/dist/jquery.smartmenus.min.js'));
 $this->headScript()->appendFile($this->assetUrl('js/tesseract.js'));
+$this->headScript()->appendFile($this->assetUrl('js/matomo.js'));
 $this->trigger('view.layout');
 $userBar = $this->userBar();
 ?>

--- a/view/layout/layout.phtml
+++ b/view/layout/layout.phtml
@@ -1,6 +1,5 @@
 <?php
 $translate = $this->plugin('translate');
-$analytics_property = $this->themeSetting('analytics_property');
 $banner_url = $this->themeSettingAssetUrl('banner');
 $banner_text = $this->themeSetting('banner_text');
 
@@ -98,7 +97,7 @@ $userBar = $this->userBar();
             <?php echo $this->partial('common/footer-site-slim'); ?>
         </div>
         <footer>
-            <?php echo $this->FooterHelper($analytics_property); ?>
+            <?php echo $this->FooterHelper(''); ?>
             <span class="powered-by"><?php echo $translate('Powered by Omeka S'); ?></span>
         </footer>
     </body>


### PR DESCRIPTION
### Why are these changes being introduced:

* We want to receive web traffic reports about users to our digital exhibits platforms, and have defined a site profile within Matomo for this purpose.

### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/post-36

### How does this address that need:

* This creates a separate javascript file in the theme, matomo.js, which has the needed JS calls to our Matomo instance. I'm hard-coding the property ID within this partial because there is no need for different sites to use different profiles.

### Document any side effects to this change:

* This approach means that changes to our Matomo setup will require code changes to the theme, and also - as far as this change goes - means that sites which don't use our theme will not be included in our analytics. Ultimately this integration should probably be handled at the module level, but for now we've just got a theme to deal with.
