### PR TITLE
Enable resource settings UI

### DIFF
--- a/config/theme.ini
+++ b/config/theme.ini
@@ -26,3 +26,13 @@ elements.nav_style.type = "Zend\Form\Element\Select"
 elements.nav_style.options.label = "Nav menu location"
 elements.nav_style.options.value_options.default = "Horizontal (above content)"
 elements.nav_style.options.value_options.vertical = "Vertical (alongside content)"
+
+resource_page_blocks.items.main[] = "values"
+resource_page_blocks.items.main[] = "itemSets"
+resource_page_blocks.items.main[] = "sitePages"
+resource_page_blocks.items.main[] = "linkedResources"
+resource_page_blocks.items.main[] = "mediaList"
+
+resource_page_blocks.item_sets.main[] = "values"
+
+resource_page_blocks.media.main[] = "values"


### PR DESCRIPTION
### Why are these changes being introduced:

Omeka's approach to controlling the structure of certain resource
displays (for Items, Item Sets, and Media records) is to allow themes
to expose a resource settings interface to site builders. This will
then allow authorized users to be able to define what information is
displayed for these records, and the order in which it appears.

Because we want to influence how these records are displayed, we need
to enable that settings UI in our theme.

### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/post-87

### How does this address that need:

This minimally enables the resource settings UI for Items, Item Sets,
and Media records. The values assigned to each display match the
default contents of each display, according to the project docs.

### Document any side effects to this change:

None, although please note that this is only part of the work of this ticket in its current state. The rest of the ticket will be to customize how the various blocks on these displays are rendered.