### PR TITLE
Hide "browse by" UI element if search in progress

### DIFF
--- a/view/omeka/site/item/browse.phtml
+++ b/view/omeka/site/item/browse.phtml
@@ -16,6 +16,11 @@ if (!isset($browse_style)) {
 }
 
 $query = $this->params()->fromQuery();
+$query_fields = array_keys($query);
+sort($query_fields);
+$query_fields_without_search = array('page', 'sort_by', 'sort_order');
+sort($query_fields_without_search);
+
 $itemSetShow = isset($itemSet);
 if ($itemSetShow) :
     $this->headLink()->appendStylesheet($this->assetUrl('css/resource-page-blocks.css', 'Omeka'));
@@ -38,9 +43,11 @@ endif;
 
 <?php echo $this->searchFilters(); ?>
 
-<div class="browse-controls">
-    <span class="browse-label">Browse by:</span><?php echo $this->browse()->renderSortSelector('items'); ?>
-</div>
+<?php if ($query_fields === $query_fields_without_search) { ?>
+    <div class="browse-controls">
+        <span class="browse-label">Browse by:</span><?php echo $this->browse()->renderSortSelector('items'); ?>
+    </div>
+<?php } ?>
 
 <?php if (!$no_advanced_search) { ?>
     <p><?php echo $this->hyperlink($translate('Advanced search'), $this->url('site/resource', ['controller' => 'item', 'action' => 'search'], ['query' => $query], true), ['class' => 'advanced-search']); ?></p>


### PR DESCRIPTION
## Developer

Omeka has made the choice to use the same template for two different contexts (browsing through items in an exhibit, and displaying search results within that exhibit). A consequence of this choice is that at times there are external factors influencing the sort order of items in the display, which can override the UI elements provided for browsing.

In order to prevent confusion at providing UI elements which can't have the expected impact, we are updating our theme's template for this /item path to prevent rendering the UI element when it cannot have the expected impact.


### Tickets affected

https://mitlibraries.atlassian.net/browse/post-167

### Version (see config/theme.ini)

- [ ] The theme's version number has been incremented, setting up a production
      deploy.

### Documentation

- [ ] Project documentation has been updated.
- [x] No documentation changes are needed.

### Accessibility

- [x] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] New flagged issues not already resolved in this PR have been ticketed 
      (link in the Pull Request details above).
- [ ] This PR contains no changes to the view layer.

### Stakeholder approval

- [x] Stakeholder approval has been confirmed (see ticket).
- [ ] Stakeholder approval will happen retroactively.
- [ ] Stakeholder approval is not needed.

### Dependencies

- [ ] New dependencies have been added
- [ ] Dependencies have been updated
- [x] No dependencies have changed

### Additional context needed to review

The linked Jira ticket provides two URLs to the staging server which demonstrate the change being made in this PR.


## Code Reviewer

##### Code

- [x] I have confirmed that the code works as intended.
- [x] Any CodeClimate issues have been fixed or confirmed as
      added technical debt.
- [x] New dependencies are appropriate or there were no changes.

##### Documentation

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [x] The documentation has been updated or is unnecessary.
