### PR TITLE
Bump version to 0.12 to override a bug deploy

### DIFF
--- a/config/theme.ini
+++ b/config/theme.ini
@@ -1,6 +1,6 @@
 [info]
 name = "Tesseract"
-version = "0.11"
+version = "0.12"
 author = "MIT Libraries"
 description = "An Omeka S theme to implement the MIT Libraries' branding materials"
 theme_link = "https://github.com/MITLibraries/mitlibraries-theme-omeka"


### PR DESCRIPTION
## Developer

It appears that the workflows we are using for automated deploys are not quite scoped correcty, as a pre-release tag on a feature branch has been deployed in production.

This PR bumps the version on the `main` branch to 0.12, giving us something to tag for an automated deploy to happen.

### Tickets affected

n/a

### Version (see config/theme.ini)

- [x] The theme's version number has been incremented, setting up a production
      deploy.

### Documentation

- [ ] Project documentation has been updated.
- [x] No documentation changes are needed.

### Accessibility

- [ ] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] New flagged issues not already resolved in this PR have been ticketed 
      (link in the Pull Request details above).
- [x] This PR contains no changes to the view layer.

### Stakeholder approval

- [ ] Stakeholder approval has been confirmed (see ticket).
- [ ] Stakeholder approval will happen retroactively.
- [x] Stakeholder approval is not needed.

### Dependencies

- [ ] New dependencies have been added
- [ ] Dependencies have been updated
- [x] No dependencies have changed

### Additional context needed to review

Merging this (and then tagging the `main` branch) will cause a number of previously-reviewed and merged PRs to be deployed in production. This is acceptable, they were just waiting for this process to be completed (which I'd hoped to do after the navigation work is done, but c'est la vie).

## Code Reviewer

##### Code

- [ ] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
      added technical debt.
- [ ] New dependencies are appropriate or there were no changes.

##### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [ ] The documentation has been updated or is unnecessary.
