### PR TITLE
Fix Theme Deployment Logic

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -11,14 +11,8 @@ jobs:
       - name: checkout code
         uses: actions/checkout@v3
 
-      - name: Exit if not main
-        run: |
-          if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
-            echo "Branch is not main, exiting."
-            exit 0
-          fi
-
       - name: deploy-theme
+        if: github.ref == 'refs/heads/main'
         run: |
           chown -R :client .
           chmod -R g+w .


### PR DESCRIPTION
## Developer

### Tickets affected

None. This issue was raised in a conversation in Slack. See this workflow run for the example of the "bug" in action:
https://github.com/MITLibraries/mitlibraries-theme-omeka/actions/runs/8884991632/job/24395317959

### Version (see config/theme.ini)

- [ ] The theme's version number has been incremented, setting up a production
      deploy.

### Documentation

- [ ] Project documentation has been updated.
- [x] No documentation changes are needed.

### Accessibility

- [ ] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] New flagged issues not already resolved in this PR have been ticketed 
      (link in the Pull Request details above).
- [x] This PR contains no changes to the view layer.

### Stakeholder approval

- [ ] Stakeholder approval has been confirmed (see ticket).
- [ ] Stakeholder approval will happen retroactively.
- [x] Stakeholder approval is not needed.

### Dependencies

- [ ] New dependencies have been added
- [ ] Dependencies have been updated
- [x] No dependencies have changed

### Additional context needed to review

The previous version of the `deploy-to-prod` workflow had a logic mistake. There was a step in the job that checked for the branch, but the exit code implemented in that step just exited the step and did not actually exit the job. So, tags on branches other than `main` would actually trigger the prod-deploy (oops). The fix here is based on this StackOverflow conversation:

* [Stack Overflow Conversation](https://stackoverflow.com/questions/71535871/trigger-github-action-only-when-new-tags-on-master-branch)

## Code Reviewer

##### Code

- [ ] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
      added technical debt.
- [ ] New dependencies are appropriate or there were no changes.

##### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [ ] The documentation has been updated or is unnecessary.
