### PR TITLE
Bug Fix: Address `git clone` Error in Deployment Workflows

### DIFF
--- a/.github/workflows/dev-manual.yml
+++ b/.github/workflows/dev-manual.yml
@@ -7,6 +7,8 @@ jobs:
     name: deploy-theme
     runs-on: [self-hosted, linux, stage]
     steps:
+      - name: clean-directory
+        run: rm -rf repo
       - name: setup-git
         run: |
           git config --global user.name "github-actions"

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -9,6 +9,8 @@ jobs:
     name: deploy-theme
     runs-on: [self-hosted, linux, prod]
     steps:
+      - name: clean-directory
+        run: rm -rf repo
       - name: setup-git
         run: |
           git config --global user.name "github-actions"

--- a/.github/workflows/stage-deploy.yml
+++ b/.github/workflows/stage-deploy.yml
@@ -15,6 +15,8 @@ jobs:
     name: deploy-theme
     runs-on: [self-hosted, linux, stage]
     steps:
+      - name: clean-directory
+        run: rm -rf repo
       - name: setup-git
         run: |
           git config --global user.name "github-actions"


### PR DESCRIPTION
## Developer

* Add a step at the start of the deployment workflows to ensure the directory for the `git clone` command is empty

### Tickets affected

- [IN-1327](https://mitlibraries.atlassian.net/browse/IN-1327)

### Version (see config/theme.ini)

- [n/a] The theme's version number has been incremented, setting up a production
      deploy.

### Documentation

- [ ] Project documentation has been updated.
- [x] No documentation changes are needed.

### Accessibility

- [ ] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] New flagged issues not already resolved in this PR have been ticketed 
      (link in the Pull Request details above).
- [ ] This PR contains no changes to the view layer.

### Stakeholder approval

- [ ] Stakeholder approval has been confirmed (see ticket).
- [ ] Stakeholder approval will happen retroactively.
- [x] Stakeholder approval is not needed.

### Dependencies

- [ ] New dependencies have been added
- [ ] Dependencies have been updated
- [x] No dependencies have changed

### Additional context needed to review

E.g., if the PR includes updated dependencies and/or data
migration, or how to confirm the feature is working.


## Code Reviewer

##### Code

- [x] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
      added technical debt.
- [ ] New dependencies are appropriate or there were no changes.

##### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [x] The documentation has been updated or is unnecessary.


[IN-1327]: https://mitlibraries.atlassian.net/browse/IN-1327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ